### PR TITLE
CI/CD setup (w/ Cloud Foundry and Travis)

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/cloudfoundry/ruby-buildpack.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: ruby
+before_script:
+  - bundle exec rake db:create
+  - bundle exec rake db:migrate
+script: bundle exec rspec
+
+addons:
+  postgresql: "9.3"
+
+deploy:
+  provider:
+    provider: cloudfoundry
+  api: https://api.cloud.gov
+  username: deploy-agile-bpa
+  password:
+    secure: bYG90NfRO1AK+a6NI9tGRRsU5yxCrAn08zBwac2tMk+BGQw2kTSRtdpwi2Rl6fLZh4riTmJEur0m38/HwrMsykliJIEC+0R20XM9csbS0AHtGLFBTKil7GgpmI2QacUT9hTp7KIXYHCvHh1YsOVws4pvoAjrjMSEu2sgGdSSwEE83Z4Ewl7JvrGwrtvia11jR9ULXsC1oANp8cQqQvbFvYegMrUOuCFr1+Vm/vQIdVsxajB8Ii3YQcVhXMYlRrQkrk1eXzX2twqUcGj5q7htao2SivX8nSv1ePqKDm8UmvXNYfFgvZNO3Rccernz/O3UcmLcDkJUU8B5/aBN9LnlOQJ0PHBWsAyP13cwjT8zgS50cvbBUOs20D2R8aRM3XCSOQ5+1Ss6fsUq9w48leAzNkNM47p7KlxwrTKM9i7b2RvQQMD1JVPlZw321sGDU/4dbbqS6F2CZLCNO0W7sZ4ddpltCJbdF/4mH3oeb+TvNxbpX8aKpz9IB7Lhb81v0xLD59V7nS9L9fpp4s2MXsSoejcXL3OOGF2/XC0pwIiJD+j00hIyZDAauWxkB6JT7eqd5im61tJxDPpqMsX7hCLRGnufvdzBEEccIYfEC5lj8LiU3E9hl8m0haB1pdhOK93pyiI93rMo/Pn/DcDkS5JTkyN9oX9iZoXcp6i1tsrd1xA=
+  organization: agile-bpa
+  space: production
+  on:
+    repo: 18F/mpt3500
+    branch: master

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rack-test', require: 'rack/test'
 end
+
+group :production do
+  gem 'cf-app-utils'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     builder (3.2.2)
+    cf-app-utils (0.6)
     chronic (0.10.2)
     diff-lcs (1.2.5)
     faraday (0.9.1)
@@ -79,6 +80,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  cf-app-utils
   chronic
   omniauth
   omniauth-github

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup -p $PORT

--- a/README.md
+++ b/README.md
@@ -2,7 +2,71 @@
 
 This app will be used to manage bids for 18F's [micro-purchase threshold experiment](https://18f.gsa.gov/2015/10/13/open-source-micropurchasing/). Vendors will be able to view open issues and bid on them, given they have GitHub accounts and are registered on [SAM.gov](https://www.sam.gov).
 
-This is a Ruby/Sinatra application using Active Record and PostgreSQL. Start the app using `rackup`. Run tests using `rspec`.
+This is a Ruby/Sinatra application using ActiveRecord and PostgreSQL.
+
+## Local Development
+
+Clone the repo and `cd` into it. Run `bundle` to install gems and install Ruby 2.2.3 if necessary.
+
+Obtain the key and secret of a GitHub application. Set them to the following environment variables:
+
+`MPT_3500_GITHUB_KEY` and `MPT_3500_GITHUB_SECRET`.
+
+To start the local server run `rackup`.
+
+### Testing
+
+```
+bundle exec rspec
+```
+
+## Deployment
+
+This application is deployed on the cloud.gov PaaS which runs on Cloud Foundry. The following instructions are 18F-specific, but could easily be adapted for other Cloud Foundry instances or other web hosts.
+
+Create the app (it's ok if the deploy fails):
+
+```
+$ cf push
+```
+
+Create the database service:
+
+```
+$ cf create-service rds shared-psql micropurchase
+```
+
+Set environment variables with `cf set-env`:
+
+```
+$ cf set-env micropurchase MPT_3500_GITHUB_KEY [the key]
+$ cf set-env micropurchase MPT_3500_GITHUB_SECRET [the secret]
+```
+
+Set up the database:
+
+```
+$ cf-ssh
+$~ bundle exec rake db:migrate
+$~ bundle exec rake db:seed
+```
+
+Restage the app:
+
+```
+cf restage micropurchase
+```
+
+### Manual Deployment
+
+```
+cf push
+```
+
+### Automated Deployment
+
+Pull requests merged into the `master` branch will be automatically deployed to https://micropurchase.18f.gov.
+>>>>>>> Getting Cloud Foundry set up.
 
 ## Public domain
 

--- a/app.rb
+++ b/app.rb
@@ -3,11 +3,11 @@ require 'sinatra/base'
 require 'omniauth'
 require 'omniauth-github'
 require 'sinatra/activerecord'
+require 'json'
 
 require_relative 'models/auction'
 require_relative 'models/bid'
 require_relative 'models/bidder'
-
 
 class App < Sinatra::Base
   register Sinatra::ActiveRecordExtension

--- a/cf-ssh.yml
+++ b/cf-ssh.yml
@@ -1,0 +1,12 @@
+applications:
+- buildpack: https://github.com/ddollar/heroku-buildpack-multi.git
+  command: curl https://18f-tmate-bootstrap.s3.amazonaws.com/tmate-debug-init.sh |
+    sh
+  domain: 18f.gov
+  hostname: micropurchase
+  instances: 1
+  memory: 128M
+  name: micropurchase-ssh
+  no-route: true
+  services:
+  - micropurchase-psql

--- a/database.yml
+++ b/database.yml
@@ -42,10 +42,12 @@ test:
   username:
   password:
 
-# production:
-#   adapter: postgresql
-#   encoding: unicode
-#   database: test-postgres_production
-#   pool: 5
-#   username:
-#   password:
+production:
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  host: <%= JSON.parse( ENV['VCAP_SERVICES'] )['rds'].first['credentials']['hostname'] rescue 'localhost' %>
+  port: <%= JSON.parse( ENV['VCAP_SERVICES'] )['rds'].first['credentials']['port'] rescue 3306 %>
+  database: <%= JSON.parse( ENV['VCAP_SERVICES'] )['rds'].first['credentials']['name'] rescue '' %>
+  username: <%= JSON.parse( ENV['VCAP_SERVICES'] )['rds'].first['credentials']['username'] rescue '' %>
+  password: <%= JSON.parse( ENV['VCAP_SERVICES'] )['rds'].first['credentials']['password'] rescue '' %>

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+- name: micropurchase
+  memory: 128M
+  instances: 1
+  domain: 18f.gov
+  hostname: micropurchase
+  buildpack: https://github.com/ddollar/heroku-buildpack-multi.git
+  services:
+    - micropurchase-psql


### PR DESCRIPTION
- Adds a manifest.yml suitable for Cloud Foundry deployment. https://micropurchase.18f.gov is up.
- Adds a travis.yml which runs the tests and handles Cloud Foundry deployment.
- Pull Requests against `master` will be deployed to Cloud Foundry upon merge.
- Updates the README with development, test, and deployment instructions.